### PR TITLE
feat: iOS and Android simulator capture mode (v0.20260317.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.20260317.0
+
+- **feat**: iOS Simulator capture mode -- `--mode simulator --platform ios` records the simulator screen via `xcrun simctl io recordVideo` while running any command (typically `xcodebuild test`).
+- **feat**: Android emulator capture mode -- `--mode simulator --platform android` records the emulator via `adb emu screenrecord` while running any command. Uses the QEMU monitor protocol to capture from the virtual framebuffer, which works on Apple Silicon where `adb shell screenrecord` produces 0 frames.
+- **feat**: Tap indicator overlays for iOS -- `ProofTapLogger.swift` is a drop-in XCUITest extension. Replace `element.tap()` with `element.proofTap()` and proof reads the logged coordinates to overlay pixel-accurate red dot + ripple ring indicators via ffmpeg post-processing.
+- **feat**: Tap indicator overlays for Android -- write `[{element, x, y, offsetMs}]` to `$PROOF_TAP_LOG` (default `/tmp/proof-android-taps.json`) from your test script and proof overlays indicators at the correct positions.
+- **fix**: Warn when `xcodebuild test` is used without `-parallel-testing-enabled NO -disable-concurrent-destination-testing` -- xcodebuild clones the simulator by default, which causes the recording to capture an idle screen instead of the active clone.
+- **fix**: Exclude test files from `tsc` compilation -- `dist/*.test.js` files were landing in dist and failing with a missing `cli.ts` reference. Test files are now compiled only by `bun test` at runtime.
+- **fix**: Scope `bun test` to `src/` and `test-app/cli/` -- prevents Playwright `.spec.ts` files from being picked up by bun's test runner.
+
 ## 0.20260316.0
 
 - **feat**: Add `--device` option for Playwright device emulation — pass any Playwright device name (e.g. `"iPhone 14"`, `"iPad Pro 11"`) to capture with that device's viewport, user-agent, and touch emulation.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 `proof` captures terminal output and browser interactions as shareable evidence -- animated HTML replays, videos, and structured reports. Run your tests through proof, get artifacts you can attach to PRs, send to stakeholders, or keep as a record.
 
-> [!NOTE]
+> [!TIP]
 > **Native mobile apps are supported.** Proof can record iOS Simulator and Android emulator screens while your XCUITest or Espresso tests run, with automatic tap indicator overlays. See [Simulator mode](#simulator-mode).
 
 ![Proof](https://raw.githubusercontent.com/automazeio/proof/main/screenshot.webp)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
 
 `proof` captures terminal output and browser interactions as shareable evidence -- animated HTML replays, videos, and structured reports. Run your tests through proof, get artifacts you can attach to PRs, send to stakeholders, or keep as a record.
 
+> [!NOTE]
+> **Native mobile apps are supported.** Proof can record iOS Simulator and Android emulator screens while your XCUITest or Espresso tests run, with automatic tap indicator overlays. See [Simulator mode](#simulator-mode).
+
 ![Proof](https://raw.githubusercontent.com/automazeio/proof/main/screenshot.webp)
 
 ## Get started
@@ -284,6 +287,12 @@ evidence/my-app/20260312/deploy-v2/
 ## Simulator mode
 
 Record your iOS Simulator or Android emulator while running UI tests. Tap indicators are overlaid automatically so reviewers can see exactly what was tapped.
+
+> [!IMPORTANT]
+> **Simulators must be installed locally.** Proof drives the simulator directly on your machine -- it does not provision or download simulators for you.
+>
+> - **iOS**: Xcode and at least one iOS Simulator runtime must be installed (via Xcode → Settings → Platforms). The simulator will be booted automatically if not already running.
+> - **Android**: Android Studio and at least one AVD must be created (via Android Studio → Tools → Device Manager). The emulator will be booted automatically if not already running.
 
 **iOS (XCUITest)**
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npm install -g @automaze/proof
 
 **Browser capture** -- runs Playwright tests with video recording, collects `.webm` files with optional cursor highlighting.
 
+**Simulator capture** -- records iOS Simulator or Android emulator screen while running your tests. Automatically overlays red dot + ripple tap indicators at the exact positions of each tap.
+
 **Report** -- a `proof.json` manifest per run, plus a generated markdown summary linking to all artifacts.
 
 ## Quick start
@@ -279,10 +281,64 @@ evidence/my-app/20260312/deploy-v2/
 | `PROOF_DIR` | Override default proof directory |
 | `PROOF_MODE` | Override auto-detection (`browser` or `terminal`) |
 
+## Simulator mode
+
+Record your iOS Simulator or Android emulator while running UI tests. Tap indicators are overlaid automatically so reviewers can see exactly what was tapped.
+
+**iOS (XCUITest)**
+
+```bash
+proof capture \
+  --app my-app \
+  --mode simulator \
+  --platform ios \
+  --device-name "iPhone 17 Pro" \
+  --command "xcodebuild test \
+    -project MyApp.xcodeproj \
+    -scheme MyApp \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+    -parallel-testing-enabled NO \
+    -disable-concurrent-destination-testing"
+```
+
+For pixel-accurate tap indicators, add `ProofTapLogger.swift` to your XCUITest target and replace `element.tap()` with `element.proofTap()`. Proof reads the tap log after the test and overlays red dot + ripple rings at the correct positions.
+
+**Android (Espresso / UIAutomator)**
+
+```bash
+proof capture \
+  --app my-app \
+  --mode simulator \
+  --platform android \
+  --command "./run-espresso-tests.sh"
+```
+
+Write tap coordinates and relative timestamps to `/tmp/proof-android-taps.json` (or `$PROOF_TAP_LOG`) from your test script:
+
+```json
+[
+  { "element": "Login", "x": 540, "y": 1200, "offsetMs": 1000 },
+  { "element": "Submit", "x": 540, "y": 1800, "offsetMs": 3500 }
+]
+```
+
+Proof overlays red dot + ripple indicators at each position. If no tap log is found, the video is still captured without indicators.
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--platform` | `ios` or `android` |
+| `--device-name` | Simulator/AVD name to boot (uses running device if omitted) |
+| `--os` | iOS version filter, e.g. `18.4` |
+| `--codec` | iOS recording codec: `h264` (default) or `hevc` |
+
 ## Requirements
 
 - **Terminal mode**: No external dependencies
 - **Browser mode**: `@playwright/test`, `video: 'on'` in Playwright config
+- **Simulator mode (iOS)**: Xcode + Simulator, `ffmpeg` on PATH
+- **Simulator mode (Android)**: Android SDK (`adb`, `emulator`), `ffmpeg` on PATH
 - **Video duration**: `ffprobe` on PATH
 
 ## Agent Skill

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+exclude = ["**/*.spec.ts"]

--- a/mental-model.md
+++ b/mental-model.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A capture SDK and CLI that records visual evidence of test execution. Two modes: **browser** (Playwright video with device emulation and cursor highlights) and **terminal** (asciicast recording with self-contained HTML player). No opinions on workflow -- just captures proof that something happened. Ships as a standalone binary with TypeScript, Python, and Go SDKs. Consumers are expected to be tools, agents, CI scripts, or non-JS SDKs that call the CLI.
+A capture SDK and CLI that records visual evidence of test execution. Three modes: **browser** (Playwright video with device emulation and cursor highlights), **terminal** (asciicast recording with self-contained HTML player), and **simulator** (iOS Simulator screen recording with tap indicator overlays). No opinions on workflow -- just captures proof that something happened. Ships as a standalone binary with TypeScript, Python, and Go SDKs. Consumers are expected to be tools, agents, CI scripts, or non-JS SDKs that call the CLI.
 
 ## Architecture
 
@@ -11,8 +11,9 @@ Proof (class)
   |
   |-- capture(options) -----> resolveMode()
   |                              |
-  |                     browser: captureVisual()   --> runs npx playwright test, collects .webm
-  |                     terminal: captureTerminal() --> spawns command, records stdout/stderr with timestamps
+  |                     browser:   captureVisual()     --> runs npx playwright test, collects .webm
+  |                     terminal:  captureTerminal()   --> spawns command, records stdout/stderr with timestamps
+  |                     simulator: captureSimulator()  --> records iOS Simulator screen, runs command, post-processes with ffmpeg
   |                              |
   |                     appendToManifest() --> writes/updates proof.json
   |
@@ -33,6 +34,10 @@ src/
   modes/
     visual.ts       -- Browser capture: runs Playwright, collects video, cursor highlight script
     terminal.ts     -- Terminal capture: pipe-based, writes .cast + self-contained .html player
+    simulator.ts    -- Simulator orchestrator: start recording, run command, stop, post-process
+    simulator-ios.ts -- xcrun simctl wrappers: device resolution, boot, recording lifecycle
+    xcresult.ts     -- Parses .xcresult bundles for tap activity timestamps
+    touch-overlay.ts -- ffmpeg post-processing: red dot + ripple ring overlay at tap positions
 
 test-app/           -- Integration test app
   capture-proof.ts  -- E2E script: creates Proof instance, captures terminal + browser
@@ -43,6 +48,11 @@ test-app/           -- Integration test app
     index.html      -- Simple order form page
     orders.spec.ts  -- Playwright test with cursor highlight injection
     playwright.config.ts -- Configures video:on, slowMo:500
+  ios/
+    ProofTestApp/   -- SwiftUI test app (tap button, counter, reset)
+      ProofTestAppUITests/
+        ProofTapLogger.swift       -- XCUITest extension: element.proofTap() logs coordinates to JSON
+        ProofTestAppUITests.swift  -- UI tests using proofTap() for coordinate logging
 ```
 
 ### Evidence output structure
@@ -52,6 +62,7 @@ proofDir/appName/yyyymmdd/run/
   label-HHmmss.html       -- Terminal player (self-contained)
   label-HHmmss.cast       -- Asciicast v2 file
   label-HHmmss.webm       -- Browser video
+  label-HHmmss.mp4        -- Simulator video (with tap overlays if available)
   proof.json               -- Manifest with entries array
   report.md                -- Generated markdown report
 ```
@@ -78,13 +89,34 @@ proofDir/appName/yyyymmdd/run/
 8. Get duration via ffprobe
 9. Append entry to proof.json (with `device`/`viewport` fields if set)
 
+### Simulator capture
+1. `assertIosReady()` checks xcrun + simctl are available
+2. `resolveIosDevice()` finds a booted simulator or boots one by name/OS
+3. `startIosRecording()` spawns `xcrun simctl io <udid> recordVideo` in background
+4. Runs the user's command (typically `xcodebuild test`) via `/bin/sh -c`
+5. Sleeps 500ms for final frames, then sends SIGINT to stop recording gracefully
+6. **Post-processing (xcodebuild tests only):**
+   a. Find latest `.xcresult` bundle, parse tap activity timestamps via `xcrun xcresulttool`
+   b. Find `proof-taps.json` in simulator's app container (written by `ProofTapLogger.swift`)
+   c. Scale UIKit points to video pixels (3x for iPhone Pro retina)
+   d. Run ffmpeg with `geq` filter to overlay red dot + ripple ring at each tap's coordinates/time
+   e. Replace original recording with overlaid version
+7. Get duration via ffprobe, return Recording
+
+#### ProofTapLogger.swift (tap coordinate logging)
+- Drop-in XCUITest extension: replace `element.tap()` with `element.proofTap()`
+- Logs `{element, x, y, width, height, timestamp}` to `proof-taps.json` in the app's Documents directory
+- `ProofTapLogger.shared.reset()` in `setUp()` clears the log between test runs
+- Coordinates are UIKit points (element center), scaled to video pixels during overlay
+
 ### Mode detection (auto)
 1. Check for `playwright.config.{ts,js,mjs}` in cwd -> browser
 2. Check package.json for `@playwright/test` or `playwright` dep -> browser
 3. Fallback -> terminal
 
 ### CLI (cli.ts)
-- **Arg mode:** `proof capture --app <name> --command <cmd> [options]`
+- **Arg mode:** `proof capture --app <name> --command <cmd> [options]` (browser/terminal)
+- **Simulator mode:** `proof capture --app <name> --command <cmd> --mode simulator --platform ios [--device-name "iPhone 17 Pro"] [--os 18.4] [--codec h264]`
 - **JSON mode:** `echo '{"action":"capture",...}' | proof --json` -- supports multiple captures in one invocation
 - All output is JSON to stdout (machine-readable for other SDKs)
 - CLI uses the same `Proof` class internally
@@ -127,6 +159,12 @@ No other runtime dependencies. Terminal capture uses only Node/Bun built-ins. AN
 - **`device` and `viewport` are mutually exclusive** -- can't set both on the same capture call.
 - **Array device/viewport fans out** -- `capture()` returns `Recording[]` when given an array. Labels are auto-suffixed (e.g. `checkout-iphone-14`, `checkout-390x844`).
 - **`bun.lock` changes** -- bun regenerates the lockfile format on dependency changes; the diff can be noisy.
+- **xcodebuild clones simulators** -- `xcodebuild test` clones the simulator by default for parallel testing. The recording captures the idle original, not the clone. Fix: pass `-parallel-testing-enabled NO -disable-concurrent-destination-testing`. Proof warns if these flags are missing.
+- **Cloned simulators are invisible** -- xcodebuild clones don't appear in `simctl list devices`. No way to detect or record them programmatically.
+- **XCUITest taps bypass UIKit** -- synthetic touches are injected at the IOKit/HID level, completely bypassing the UIKit event pipeline. No swizzle, gesture recognizer, or overlay can intercept them. That's why tap indicators use post-processing, not runtime injection.
+- **simctl recordVideo captures raw framebuffer** -- iOS Simulator's built-in touch indicators (Settings > Accessibility > Touch) don't appear in recordVideo output.
+- **Tap log location** -- `proof-taps.json` is written to the test runner app's Documents directory on the simulator filesystem. After the test, proof searches `~/Library/Developer/CoreSimulator/Devices/<udid>/data/Containers/Data/Application/` for the file.
+- **Point-to-pixel scaling** -- UIKit coordinates are in points; video is in pixels. For iPhone Pro (3x retina), multiply by 3. `guessScaleFactor()` in touch-overlay.ts infers the scale from video resolution.
 
 ## Lessons Learned
 
@@ -134,3 +172,6 @@ No other runtime dependencies. Terminal capture uses only Node/Bun built-ins. AN
 - **`script` command is unreliable** -- first terminal implementation used `script` (macOS/Linux). Produced `^D` artifacts, platform-specific args, and raw ANSI blobs. Pipe-based capture with `spawn` is simpler and more portable.
 - **ffprobe for duration** -- `duration.ts` shells out to `ffprobe -v error -show_entries format=duration`. Works for both .webm and .mp4.
 - **Self-contained HTML is the right call** -- no CDN, no external player library. The HTML file works forever, offline, in any browser. Worth the ~7KB per file.
+- **Post-processing beats runtime overlay** -- tried multiple runtime approaches for tap indicators (swizzling, gesture recognizers, overlay windows). None work because XCUITest taps don't flow through UIKit. ffmpeg post-processing is reliable and keeps the test app unmodified.
+- **SIGINT for simctl recordVideo** -- the only clean way to stop `xcrun simctl io recordVideo`. SIGTERM or SIGKILL produces a corrupt/empty file. The 500ms sleep before SIGINT ensures the last frames are captured.
+- **xcresult has timestamps but no coordinates** -- `xcrun xcresulttool` gives activity summaries ("Tap button") with timestamps but no pixel coordinates. That's why ProofTapLogger.swift exists: the test itself must log where taps happened.

--- a/mental-model.md
+++ b/mental-model.md
@@ -36,6 +36,7 @@ src/
     terminal.ts     -- Terminal capture: pipe-based, writes .cast + self-contained .html player
     simulator.ts    -- Simulator orchestrator: start recording, run command, stop, post-process
     simulator-ios.ts -- xcrun simctl wrappers: device resolution, boot, recording lifecycle
+    simulator-android.ts -- adb/emulator wrappers: device resolution, AVD boot, recording lifecycle
     xcresult.ts     -- Parses .xcresult bundles for tap activity timestamps
     touch-overlay.ts -- ffmpeg post-processing: red dot + ripple ring overlay at tap positions
 
@@ -89,7 +90,7 @@ proofDir/appName/yyyymmdd/run/
 8. Get duration via ffprobe
 9. Append entry to proof.json (with `device`/`viewport` fields if set)
 
-### Simulator capture
+### Simulator capture (iOS)
 1. `assertIosReady()` checks xcrun + simctl are available
 2. `resolveIosDevice()` finds a booted simulator or boots one by name/OS
 3. `startIosRecording()` spawns `xcrun simctl io <udid> recordVideo` in background
@@ -109,6 +110,21 @@ proofDir/appName/yyyymmdd/run/
 - `ProofTapLogger.shared.reset()` in `setUp()` clears the log between test runs
 - Coordinates are UIKit points (element center), scaled to video pixels during overlay
 
+### Simulator capture (Android)
+1. `assertAndroidReady()` checks adb is available (looks in `~/Library/Android/sdk/platform-tools/`)
+2. `resolveAndroidDevice()` finds a running emulator or boots an AVD by name
+3. `startAndroidRecording()` issues `adb emu screenrecord start <host-path>` -- saves directly to host
+4. Runs the user's command via `/bin/sh -c`
+5. Sleeps 500ms, then issues `adb emu screenrecord stop`
+6. Converts `.webm` to `.mp4` via ffmpeg
+7. **Post-processing (optional):** reads `$PROOF_TAP_LOG` (default `/tmp/proof-android-taps.json`)
+   - Format: `[{element, x, y, offsetMs}]` where x/y are video pixel coordinates
+   - Applies ffmpeg overlay with `scaleFactor=1` (video is already at native device resolution)
+8. Get duration via ffprobe, return Recording
+
+#### Why `adb emu screenrecord` not `adb shell screenrecord`
+`adb shell screenrecord` uses the Android hardware AVC encoder. On Apple Silicon emulators with the `gfxstream` graphics backend, this produces 0 frames -- the encoder can't capture from a virtual display. `adb emu screenrecord` captures directly from the emulator's virtual framebuffer via the QEMU monitor protocol, bypassing the hardware encoder entirely.
+
 ### Mode detection (auto)
 1. Check for `playwright.config.{ts,js,mjs}` in cwd -> browser
 2. Check package.json for `@playwright/test` or `playwright` dep -> browser
@@ -116,7 +132,8 @@ proofDir/appName/yyyymmdd/run/
 
 ### CLI (cli.ts)
 - **Arg mode:** `proof capture --app <name> --command <cmd> [options]` (browser/terminal)
-- **Simulator mode:** `proof capture --app <name> --command <cmd> --mode simulator --platform ios [--device-name "iPhone 17 Pro"] [--os 18.4] [--codec h264]`
+- **Simulator mode (iOS):** `proof capture --app <name> --command <cmd> --mode simulator --platform ios [--device-name "iPhone 17 Pro"] [--os 18.4] [--codec h264]`
+- **Simulator mode (Android):** `proof capture --app <name> --command <cmd> --mode simulator --platform android [--device-name "Pixel_3a"]`
 - **JSON mode:** `echo '{"action":"capture",...}' | proof --json` -- supports multiple captures in one invocation
 - All output is JSON to stdout (machine-readable for other SDKs)
 - CLI uses the same `Proof` class internally
@@ -165,6 +182,9 @@ No other runtime dependencies. Terminal capture uses only Node/Bun built-ins. AN
 - **simctl recordVideo captures raw framebuffer** -- iOS Simulator's built-in touch indicators (Settings > Accessibility > Touch) don't appear in recordVideo output.
 - **Tap log location** -- `proof-taps.json` is written to the test runner app's Documents directory on the simulator filesystem. After the test, proof searches `~/Library/Developer/CoreSimulator/Devices/<udid>/data/Containers/Data/Application/` for the file.
 - **Point-to-pixel scaling** -- UIKit coordinates are in points; video is in pixels. For iPhone Pro (3x retina), multiply by 3. `guessScaleFactor()` in touch-overlay.ts infers the scale from video resolution.
+- **Android `adb shell screenrecord` produces 0 frames** -- on Apple Silicon with the gfxstream backend, the hardware AVC encoder cannot capture from a virtual display. Use `adb emu screenrecord` instead, which captures via the QEMU monitor.
+- **Android tap log is caller-provided** -- unlike iOS (where proof reads the xcresult + app container automatically), Android requires the test script to write `/tmp/proof-android-taps.json`. Set `$PROOF_TAP_LOG` to override the path.
+- **`adb emu screenrecord` outputs `.webm`** -- must be converted to `.mp4` via ffmpeg for consistency. The webm is deleted after conversion.
 
 ## Lessons Learned
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "tsc && bun build ./src/index.ts --outdir ./dist --target node && bun build ./src/cli.ts --outdir ./dist --target node",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit",
-    "test": "bun test",
+    "test": "bun test src/ test-app/cli/",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/skills/proof/SKILL.md
+++ b/skills/proof/SKILL.md
@@ -7,13 +7,15 @@ description: >
   standalone binary, TypeScript, Python, or Go SDKs. Key use cases: attaching terminal
   output to a PR so reviewers can replay the test session instead of trusting a screenshot;
   generating a markdown proof report to embed in PR descriptions or tickets; recording a
-  browser test run as a self-contained HTML video to share with a PM or QA team; or creating
-  an audit trail that ties passing tests to a specific git commit. Trigger on phrases like
-  "attach evidence to PR", "save test output as artifact", "replayable test recording",
-  "proof report", "record my test run", "share test results", "visual proof tests pass",
-  "terminal recording of tests", or whenever someone wants reviewers or stakeholders to
-  see test execution without re-running it themselves. Also trigger when the user mentions
-  proof, @automaze/proof, or automaze-proof directly.
+  browser test run as a self-contained HTML video to share with a PM or QA team; recording
+  an iOS Simulator or Android emulator screen while XCUITest or Espresso tests run, with
+  automatic tap indicator overlays; or creating an audit trail that ties passing tests to a
+  specific git commit. Trigger on phrases like "attach evidence to PR", "save test output
+  as artifact", "replayable test recording", "proof report", "record my test run", "share
+  test results", "visual proof tests pass", "terminal recording of tests", "record iOS
+  simulator", "record Android emulator", "capture mobile tests", or whenever someone wants
+  reviewers or stakeholders to see test execution without re-running it themselves. Also
+  trigger when the user mentions proof, @automaze/proof, or automaze-proof directly.
 ---
 
 # proof
@@ -26,6 +28,7 @@ Capture evidence that code works. Terminal replays, browser videos, structured r
 - User wants visual evidence of a command running
 - User needs to generate a proof report
 - User wants to attach test recordings to PRs or share them
+- User wants to record an iOS Simulator or Android emulator while running mobile UI tests
 - User mentions "proof", "evidence", or "capture" in the context of testing
 
 ## Install
@@ -84,6 +87,56 @@ proof capture \
   --label <label> \
   --dir <output-dir>
 ```
+
+### Simulator capture (iOS)
+
+Records the iOS Simulator screen while running XCUITest (or any command). Requires Xcode and at least one simulator runtime installed locally.
+
+```bash
+proof capture \
+  --app <app-name> \
+  --mode simulator \
+  --platform ios \
+  --device-name "iPhone 17 Pro" \
+  --command "xcodebuild test \
+    -project MyApp.xcodeproj \
+    -scheme MyApp \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+    -parallel-testing-enabled NO \
+    -disable-concurrent-destination-testing" \
+  --label ui-tests \
+  --dir <output-dir>
+```
+
+For pixel-accurate tap indicators, add `ProofTapLogger.swift` to the XCUITest target and replace `element.tap()` with `element.proofTap()`. Proof reads the tap log after the test and overlays red dot + ripple rings at the correct positions.
+
+### Simulator capture (Android)
+
+Records the Android emulator screen while running Espresso or any command. Requires Android SDK and at least one AVD created locally.
+
+```bash
+proof capture \
+  --app <app-name> \
+  --mode simulator \
+  --platform android \
+  --device-name "Pixel_3a" \
+  --command "./gradlew connectedAndroidTest" \
+  --label ui-tests \
+  --dir <output-dir>
+```
+
+For tap indicators, write a JSON tap log from your test script:
+
+```bash
+cat > /tmp/proof-android-taps.json << 'EOF'
+[
+  { "element": "Login", "x": 540, "y": 1200, "offsetMs": 1000 },
+  { "element": "Submit", "x": 540, "y": 1800, "offsetMs": 3500 }
+]
+EOF
+```
+
+Proof reads `$PROOF_TAP_LOG` (default `/tmp/proof-android-taps.json`) after recording and overlays indicators.
 
 ### Generate report
 
@@ -265,9 +318,12 @@ proof report --app my-app --dir ./evidence --run full-suite --format md
 
 - Terminal mode requires `--command`
 - Browser mode requires `--test-file`
+- Simulator mode requires `--command` and `--platform`
 - `--app` is always required
 - CLI always outputs JSON to stdout, errors go to stderr
 - Report generation requires at least one capture in the run
+- Simulator mode requires the simulator/emulator to be installed locally -- proof does not download or provision them
+- For iOS xcodebuild tests, always pass `-parallel-testing-enabled NO -disable-concurrent-destination-testing` or the recording will capture an idle screen (xcodebuild clones the simulator by default)
 
 ## References
 

--- a/skills/proof/references/cli.md
+++ b/skills/proof/references/cli.md
@@ -19,7 +19,7 @@ npm install -g @automaze/proof
 
 ### `proof capture`
 
-Record a terminal command or Playwright test.
+Record a terminal command, Playwright test, or mobile simulator.
 
 ```bash
 # Terminal capture
@@ -27,6 +27,17 @@ proof capture --app my-app --command "pytest tests/ -v" --mode terminal
 
 # Browser capture
 proof capture --app my-app --test-file tests/checkout.spec.ts --mode browser
+
+# iOS Simulator capture
+proof capture --app my-app --mode simulator --platform ios \
+  --device-name "iPhone 17 Pro" \
+  --command "xcodebuild test -project MyApp.xcodeproj -scheme MyApp \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+    -parallel-testing-enabled NO -disable-concurrent-destination-testing"
+
+# Android emulator capture
+proof capture --app my-app --mode simulator --platform android \
+  --command "./gradlew connectedAndroidTest"
 
 # With all options
 proof capture \
@@ -91,11 +102,15 @@ Print the installed version.
 | `--app <name>` | App name. Used in directory paths and manifest. | Yes |
 | `--dir <path>` | Proof directory. Default: `$TMPDIR/proof` | No |
 | `--run <name>` | Run name. Default: HHMM of current time | No |
-| `--command <cmd>` | Shell command to run | Yes (terminal mode) |
+| `--command <cmd>` | Shell command to run | Yes (terminal / simulator mode) |
 | `--test-file <file>` | Playwright test file path | Yes (browser mode) |
 | `--test-name <name>` | Specific test name filter (Playwright `-g`) | No |
 | `--label <label>` | Artifact filename prefix | No |
-| `--mode <mode>` | `browser`, `terminal`, or `auto` | No |
+| `--mode <mode>` | `browser`, `terminal`, `simulator`, or `auto` | No |
+| `--platform <p>` | `ios` or `android` | Yes (simulator mode) |
+| `--device-name <n>` | Simulator/AVD name to boot (uses running device if omitted) | No |
+| `--os <version>` | iOS version filter, e.g. `18.4` | No |
+| `--codec <codec>` | iOS recording codec: `h264` (default) or `hevc` | No |
 | `--format <fmt>` | Report format: `md`, `html`, `archive` (comma-separated for multiple) | No |
 | `--description <text>` | Human-readable description stored in manifest | No |
 
@@ -234,3 +249,4 @@ Exit code is `1` on error, `0` on success.
 |----------|-------------|
 | `PROOF_DIR` | Override default proof directory (same as `--dir`) |
 | `PROOF_MODE` | Override auto-detection (`browser` or `terminal`) |
+| `PROOF_TAP_LOG` | Path to Android tap log JSON (default: `/tmp/proof-android-taps.json`) |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,10 +8,19 @@ interface CaptureArgs {
   testFile?: string;
   testName?: string;
   label?: string;
-  mode?: "browser" | "terminal" | "auto";
+  mode?: "browser" | "terminal" | "simulator" | "auto";
   description?: string;
   device?: string | string[];
   viewport?: string | string[];
+  platform?: "ios" | "android";
+  simulator?: {
+    deviceName?: string;
+    deviceId?: string;
+    os?: string;
+    codec?: string;
+    bitRate?: number;
+    size?: string;
+  };
 }
 
 interface CliInput {
@@ -28,10 +37,19 @@ interface CliInput {
   testFile?: string;
   testName?: string;
   label?: string;
-  mode?: "browser" | "terminal" | "auto";
+  mode?: "browser" | "terminal" | "simulator" | "auto";
   description?: string;
   device?: string | string[];
   viewport?: string | string[];
+  platform?: "ios" | "android";
+  simulator?: {
+    deviceName?: string;
+    deviceId?: string;
+    os?: string;
+    codec?: string;
+    bitRate?: number;
+    size?: string;
+  };
 }
 
 async function main() {
@@ -76,6 +94,10 @@ async function main() {
       process.exit(1);
     }
 
+    const simulatorOpts = parsed.deviceName || parsed.os || parsed.codec
+      ? { deviceName: parsed.deviceName, os: parsed.os, codec: parsed.codec }
+      : undefined;
+
     const config: CliInput = {
       action: "capture",
       appName: parsed.appName,
@@ -85,10 +107,12 @@ async function main() {
       testFile: parsed.testFile,
       testName: parsed.testName,
       label: parsed.label,
-      mode: parsed.mode as "browser" | "terminal" | "auto" | undefined,
+      mode: parsed.mode as "browser" | "terminal" | "simulator" | "auto" | undefined,
       description: parsed.description,
       device: parsed.device?.includes(",") ? parsed.device.split(",") : parsed.device,
       viewport: parsed.viewport?.includes(",") ? parsed.viewport.split(",") : parsed.viewport,
+      platform: parsed.platform as "ios" | "android" | undefined,
+      simulator: simulatorOpts,
     };
     await runFromConfig(config);
   } else {
@@ -132,6 +156,8 @@ async function runFromConfig(config: CliInput) {
       description: config.description,
       device: config.device,
       viewport: config.viewport,
+      platform: config.platform,
+      simulator: config.simulator,
     },
   ];
 
@@ -146,6 +172,8 @@ async function runFromConfig(config: CliInput) {
       description: cap.description,
       device: cap.device,
       viewport: cap.viewport,
+      platform: cap.platform,
+      simulator: cap.simulator,
     });
     const recordings = Array.isArray(result) ? result : [result];
     for (const recording of recordings) {
@@ -181,6 +209,10 @@ function parseArgs(args: string[]): Record<string, string | undefined> {
     "--format": "format",
     "--device": "device",
     "--viewport": "viewport",
+    "--platform": "platform",
+    "--device-name": "deviceName",
+    "--os": "os",
+    "--codec": "codec",
     "--description": "description",
   };
 
@@ -209,6 +241,7 @@ function printUsage() {
 Usage:
   proof capture --app <name> --command <cmd> [options]
   proof capture --app <name> --test-file <file> --mode browser [options]
+  proof capture --app <name> --command <cmd> --mode simulator --platform ios [options]
   proof report  --app <name> [--format <fmt>] [options]
   proof --json  < config.json
 
@@ -216,13 +249,17 @@ Options:
   --app <name>          App name (required)
   --dir <path>          Proof directory (default: $TMPDIR/proof)
   --run <name>          Run name (default: HHMM)
-  --command <cmd>       Command to run (required for terminal mode)
+  --command <cmd>       Command to run (required for terminal/simulator mode)
   --test-file <file>    Playwright test file (required for browser mode)
   --test-name <name>    Specific test name filter
   --label <label>       Artifact filename prefix
-  --mode <mode>         browser | terminal | auto
+  --mode <mode>         browser | terminal | simulator | auto
   --device <name>       Playwright device (e.g. "iPhone 14", comma-separated for multiple)
   --viewport <WxH>      Custom viewport (e.g. "390x844", comma-separated for multiple)
+  --platform <p>        Simulator platform: ios | android
+  --device-name <name>  iOS Simulator name (e.g. "iPhone 17 Pro")
+  --os <version>        iOS version filter (e.g. "26.3")
+  --codec <codec>       iOS video codec (default: h264)
   --format <fmt>        Report format: md | html | archive (comma-separated for multiple)
   --description <text>  Human-readable description
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -246,16 +246,22 @@ describe("Proof", () => {
       ).rejects.toThrow("simulator mode requires platform");
     });
 
-    test("throws for android (not yet implemented)", async () => {
+    test("android: enters android code path (fails on missing device, not stub)", async () => {
       const proof = new Proof({
         appName: "test-app",
         proofDir: tempDir,
         run: "test-run",
       });
-
-      expect(
-        proof.capture({ mode: "simulator", platform: "android", command: "echo hi", label: "fail" })
-      ).rejects.toThrow("Android simulator capture is not yet implemented");
+      // Use a fake deviceId to skip emulator boot and fail fast on adb pull.
+      // Verifies the Android code path exists (no longer a stub).
+      const capture = proof.capture({
+        mode: "simulator",
+        platform: "android",
+        command: "echo hi",
+        label: "fail",
+        simulator: { deviceId: "emulator-9999" },
+      });
+      await expect(capture).rejects.not.toThrow("Android simulator capture is not yet implemented");
     });
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -221,6 +221,44 @@ describe("Proof", () => {
     });
   });
 
+  describe("capture (simulator mode)", () => {
+    test("throws if command is missing", async () => {
+      const proof = new Proof({
+        appName: "test-app",
+        proofDir: tempDir,
+        run: "test-run",
+      });
+
+      expect(
+        proof.capture({ mode: "simulator", platform: "ios", label: "fail" })
+      ).rejects.toThrow("simulator mode requires command");
+    });
+
+    test("throws if platform is missing", async () => {
+      const proof = new Proof({
+        appName: "test-app",
+        proofDir: tempDir,
+        run: "test-run",
+      });
+
+      expect(
+        proof.capture({ mode: "simulator", command: "echo hi", label: "fail" })
+      ).rejects.toThrow("simulator mode requires platform");
+    });
+
+    test("throws for android (not yet implemented)", async () => {
+      const proof = new Proof({
+        appName: "test-app",
+        proofDir: tempDir,
+        run: "test-run",
+      });
+
+      expect(
+        proof.capture({ mode: "simulator", platform: "android", command: "echo hi", label: "fail" })
+      ).rejects.toThrow("Android simulator capture is not yet implemented");
+    });
+  });
+
   describe("manifest", () => {
     test("creates proof.json with entries on capture", async () => {
       const proof = new Proof({

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { existsSync } from "fs";
 import { detectMode } from "./detect";
 import { captureVisual } from "./modes/visual";
 import { captureTerminal } from "./modes/terminal";
+import { captureSimulator } from "./modes/simulator";
 import { generateReport } from "./report";
 import type {
   ProofConfig,
@@ -169,12 +170,27 @@ export class Proof {
         );
         break;
       }
+      case "simulator": {
+        if (!options.command) {
+          throw new Error("simulator mode requires command");
+        }
+        if (!options.platform) {
+          throw new Error("simulator mode requires platform (ios or android)");
+        }
+        recording = await captureSimulator(
+          options as CaptureOptions & { command: string },
+          runDir,
+          filePrefix,
+        );
+        break;
+      }
     }
 
     const source = options.testFile ? basename(options.testFile) : options.command ?? mode;
     const fallbackDescriptions: Record<Exclude<RecordingMode, "auto">, string> = {
       browser: `Playwright browser test recording of ${source}${options.testName ? ` — test: "${options.testName}"` : ""}`,
       terminal: `Terminal capture: ${source}`,
+      simulator: `Simulator recording (${options.platform ?? "ios"}): ${source}`,
     };
 
     const entry: ProofEntry = {
@@ -189,6 +205,7 @@ export class Proof {
       description: options.description ?? fallbackDescriptions[mode],
       device: singleDevice,
       viewport: singleViewport,
+      platform: options.platform,
     };
 
     await this.appendToManifest(entry);

--- a/src/modes/simulator-android.ts
+++ b/src/modes/simulator-android.ts
@@ -1,0 +1,278 @@
+import { execSync, spawn, type ChildProcess } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+const ADB = findAdb();
+const EMULATOR = findEmulator();
+
+function findAdb(): string {
+  const sdkPath = `${process.env.HOME}/Library/Android/sdk/platform-tools/adb`;
+  if (existsSync(sdkPath)) return sdkPath;
+  try {
+    execSync("adb version", { stdio: "ignore" });
+    return "adb";
+  } catch {
+    return sdkPath; // will fail with a clear error at assertAndroidReady()
+  }
+}
+
+function findEmulator(): string {
+  const sdkPath = `${process.env.HOME}/Library/Android/sdk/emulator/emulator`;
+  if (existsSync(sdkPath)) return sdkPath;
+  return "emulator";
+}
+
+export interface AndroidDevice {
+  serial: string;
+  avdName: string;
+}
+
+export function assertAndroidReady(): void {
+  try {
+    execSync(`"${ADB}" version`, { stdio: "ignore" });
+  } catch {
+    throw new Error(
+      `adb not found. Install Android SDK platform-tools or set ANDROID_HOME. ` +
+      `Tried: ${ADB}`
+    );
+  }
+}
+
+export function getRunningEmulators(): AndroidDevice[] {
+  try {
+    const output = execSync(`"${ADB}" devices`, { encoding: "utf-8" });
+    const lines = output.split("\n").slice(1); // skip header
+    const devices: AndroidDevice[] = [];
+    for (const line of lines) {
+      const [serial, state] = line.trim().split(/\s+/);
+      if (!serial || state !== "device" || !serial.startsWith("emulator-")) continue;
+      let avdName = serial;
+      try {
+        avdName = execSync(`"${ADB}" -s ${serial} emu avd name`, {
+          encoding: "utf-8",
+        }).split("\n")[0].trim();
+      } catch {
+        // ignore
+      }
+      devices.push({ serial, avdName });
+    }
+    return devices;
+  } catch {
+    return [];
+  }
+}
+
+export function listAvds(): string[] {
+  try {
+    const output = execSync(`"${EMULATOR}" -list-avds`, { encoding: "utf-8" });
+    return output
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export function bootAvd(avdName: string): AndroidDevice {
+  console.error(`Booting Android emulator: ${avdName}`);
+  const proc = spawn(EMULATOR, ["-avd", avdName, "-no-audio", "-no-boot-anim"], {
+    detached: true,
+    stdio: "ignore",
+  });
+  proc.unref();
+
+  // Wait for device to appear and fully boot
+  execSync(`"${ADB}" wait-for-device`, { timeout: 120_000 });
+
+  // Wait for boot_completed
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    try {
+      const val = execSync(
+        `"${ADB}" shell getprop sys.boot_completed`,
+        { encoding: "utf-8", timeout: 5000 },
+      ).trim();
+      if (val === "1") break;
+    } catch {
+      // not ready yet
+    }
+    execSync("sleep 2");
+  }
+
+  const running = getRunningEmulators();
+  const match = running.find((d) => d.avdName === avdName);
+  if (!match) {
+    // fallback: use first running emulator
+    if (running.length > 0) return running[0];
+    throw new Error(`Emulator booted but not found in adb devices`);
+  }
+  return match;
+}
+
+export function resolveAndroidDevice(avdName?: string, deviceId?: string): AndroidDevice {
+  if (deviceId) {
+    return { serial: deviceId, avdName: deviceId };
+  }
+
+  const running = getRunningEmulators();
+
+  if (!avdName) {
+    if (running.length === 0) {
+      const avds = listAvds();
+      if (avds.length === 0) {
+        throw new Error(
+          "No Android emulator running and no AVDs found. " +
+          "Create an AVD in Android Studio (Tools > Device Manager)."
+        );
+      }
+      return bootAvd(avds[0]);
+    }
+    return running[0];
+  }
+
+  const match = running.find((d) => d.avdName === avdName);
+  if (match) return match;
+
+  const avds = listAvds();
+  const avdMatch = avds.find((a) => a === avdName);
+  if (!avdMatch) {
+    throw new Error(
+      `No AVD found matching "${avdName}". Available: ${avds.join(", ")}`
+    );
+  }
+
+  return bootAvd(avdName);
+}
+
+export interface AndroidRecordingHandle {
+  stop: () => Promise<void>;
+  remoteFiles: string[];
+}
+
+// screenrecord has a 180s limit; we chain segments for longer recordings
+const SEGMENT_DURATION = 175;
+
+export function startAndroidRecording(
+  serial: string,
+  opts: { bitRate?: number; size?: string } = {},
+): AndroidRecordingHandle {
+  const remoteFiles: string[] = [];
+  let segmentIndex = 0;
+  let stopped = false;
+  let currentProc: ChildProcess | null = null;
+  let segmentTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function remotePathForSegment(i: number): string {
+    return `/sdcard/proof-recording-${i}.mp4`;
+  }
+
+  function startSegment(): void {
+    const remotePath = remotePathForSegment(segmentIndex);
+    remoteFiles.push(remotePath);
+
+    const args = ["-s", serial, "shell", "screenrecord"];
+    if (opts.bitRate) args.push("--bit-rate", String(opts.bitRate));
+    if (opts.size) args.push("--size", opts.size);
+    args.push("--time-limit", String(SEGMENT_DURATION), remotePath);
+
+    currentProc = spawn(ADB, args, { stdio: "ignore" });
+
+    currentProc.on("close", () => {
+      if (!stopped) {
+        // Natural end of segment (hit 175s limit), start next
+        segmentIndex++;
+        startSegment();
+      }
+    });
+
+    // Also chain proactively just before the limit
+    segmentTimer = setTimeout(() => {
+      if (!stopped && currentProc) {
+        segmentIndex++;
+        startSegment();
+      }
+    }, (SEGMENT_DURATION - 2) * 1000);
+  }
+
+  startSegment();
+
+  return {
+    remoteFiles,
+    stop: () =>
+      new Promise<void>((resolve) => {
+        stopped = true;
+        if (segmentTimer) clearTimeout(segmentTimer);
+        if (currentProc) {
+          currentProc.on("close", () => resolve());
+          currentProc.kill("SIGINT");
+          setTimeout(() => {
+            if (currentProc && !currentProc.killed) currentProc.kill("SIGKILL");
+            resolve();
+          }, 10_000);
+        } else {
+          resolve();
+        }
+      }),
+  };
+}
+
+export function pullAndMergeRecording(
+  serial: string,
+  remoteFiles: string[],
+  localOutputPath: string,
+): void {
+  if (remoteFiles.length === 0) return;
+
+  if (remoteFiles.length === 1) {
+    execSync(`"${ADB}" -s ${serial} pull "${remoteFiles[0]}" "${localOutputPath}"`, {
+      stdio: "ignore",
+    });
+    execSync(`"${ADB}" -s ${serial} shell rm -f "${remoteFiles[0]}"`, { stdio: "ignore" });
+    return;
+  }
+
+  // Pull all segments and concatenate with ffmpeg
+  const tmpDir = require("os").tmpdir();
+  const localSegments: string[] = [];
+
+  for (let i = 0; i < remoteFiles.length; i++) {
+    const localSeg = join(tmpDir, `proof-seg-${i}.mp4`);
+    localSegments.push(localSeg);
+    execSync(`"${ADB}" -s ${serial} pull "${remoteFiles[i]}" "${localSeg}"`, {
+      stdio: "ignore",
+    });
+    execSync(`"${ADB}" -s ${serial} shell rm -f "${remoteFiles[i]}"`, { stdio: "ignore" });
+  }
+
+  // Build ffmpeg concat list
+  const concatList = join(tmpDir, "proof-concat.txt");
+  const listContent = localSegments.map((f) => `file '${f}'`).join("\n");
+  require("fs").writeFileSync(concatList, listContent);
+
+  execSync(
+    `ffmpeg -f concat -safe 0 -i "${concatList}" -c copy "${localOutputPath}" -y`,
+    { stdio: "ignore" },
+  );
+
+  for (const seg of localSegments) {
+    try { require("fs").unlinkSync(seg); } catch { /* ignore */ }
+  }
+  try { require("fs").unlinkSync(concatList); } catch { /* ignore */ }
+}
+
+export function enableTouchIndicators(serial: string): void {
+  try {
+    execSync(`"${ADB}" -s ${serial} shell settings put system show_touches 1`, {
+      stdio: "ignore",
+    });
+  } catch { /* non-fatal */ }
+}
+
+export function disableTouchIndicators(serial: string): void {
+  try {
+    execSync(`"${ADB}" -s ${serial} shell settings put system show_touches 0`, {
+      stdio: "ignore",
+    });
+  } catch { /* non-fatal */ }
+}

--- a/src/modes/simulator-android.ts
+++ b/src/modes/simulator-android.ts
@@ -147,118 +147,44 @@ export function resolveAndroidDevice(avdName?: string, deviceId?: string): Andro
 
 export interface AndroidRecordingHandle {
   stop: () => Promise<void>;
-  remoteFiles: string[];
+  localWebmPath: string;
 }
 
-// screenrecord has a 180s limit; we chain segments for longer recordings
-const SEGMENT_DURATION = 175;
-
+// Uses `adb emu screenrecord` which saves directly to the host filesystem.
+// `adb shell screenrecord` produces 0 frames on emulators using the gfxstream
+// graphics backend (default on Apple Silicon) because the AVC encoder can't
+// capture from a virtual display in that configuration.
 export function startAndroidRecording(
   serial: string,
+  localWebmPath: string,
   opts: { bitRate?: number; size?: string } = {},
 ): AndroidRecordingHandle {
-  const remoteFiles: string[] = [];
-  let segmentIndex = 0;
-  let stopped = false;
-  let currentProc: ChildProcess | null = null;
-  let segmentTimer: ReturnType<typeof setTimeout> | null = null;
+  const args = ["emu", "screenrecord", "start"];
+  if (opts.bitRate) args.push("--bit-rate", String(opts.bitRate));
+  if (opts.size) args.push("--size", opts.size);
+  args.push(localWebmPath);
 
-  function remotePathForSegment(i: number): string {
-    return `/sdcard/proof-recording-${i}.mp4`;
-  }
-
-  function startSegment(): void {
-    const remotePath = remotePathForSegment(segmentIndex);
-    remoteFiles.push(remotePath);
-
-    const args = ["-s", serial, "shell", "screenrecord"];
-    if (opts.bitRate) args.push("--bit-rate", String(opts.bitRate));
-    if (opts.size) args.push("--size", opts.size);
-    args.push("--time-limit", String(SEGMENT_DURATION), remotePath);
-
-    currentProc = spawn(ADB, args, { stdio: "ignore" });
-
-    currentProc.on("close", () => {
-      if (!stopped) {
-        // Natural end of segment (hit 175s limit), start next
-        segmentIndex++;
-        startSegment();
-      }
-    });
-
-    // Also chain proactively just before the limit
-    segmentTimer = setTimeout(() => {
-      if (!stopped && currentProc) {
-        segmentIndex++;
-        startSegment();
-      }
-    }, (SEGMENT_DURATION - 2) * 1000);
-  }
-
-  startSegment();
+  execSync(`"${ADB}" -s ${serial} ${args.join(" ")}`, { stdio: "ignore" });
 
   return {
-    remoteFiles,
+    localWebmPath,
     stop: () =>
       new Promise<void>((resolve) => {
-        stopped = true;
-        if (segmentTimer) clearTimeout(segmentTimer);
-        if (currentProc) {
-          currentProc.on("close", () => resolve());
-          currentProc.kill("SIGINT");
-          setTimeout(() => {
-            if (currentProc && !currentProc.killed) currentProc.kill("SIGKILL");
-            resolve();
-          }, 10_000);
-        } else {
-          resolve();
-        }
+        try {
+          execSync(`"${ADB}" -s ${serial} emu screenrecord stop`, { stdio: "ignore" });
+        } catch { /* ignore */ }
+        // Give the emulator a moment to finalize the file
+        setTimeout(resolve, 1000);
       }),
   };
 }
 
-export function pullAndMergeRecording(
-  serial: string,
-  remoteFiles: string[],
-  localOutputPath: string,
-): void {
-  if (remoteFiles.length === 0) return;
-
-  if (remoteFiles.length === 1) {
-    execSync(`"${ADB}" -s ${serial} pull "${remoteFiles[0]}" "${localOutputPath}"`, {
-      stdio: "ignore",
-    });
-    execSync(`"${ADB}" -s ${serial} shell rm -f "${remoteFiles[0]}"`, { stdio: "ignore" });
-    return;
-  }
-
-  // Pull all segments and concatenate with ffmpeg
-  const tmpDir = require("os").tmpdir();
-  const localSegments: string[] = [];
-
-  for (let i = 0; i < remoteFiles.length; i++) {
-    const localSeg = join(tmpDir, `proof-seg-${i}.mp4`);
-    localSegments.push(localSeg);
-    execSync(`"${ADB}" -s ${serial} pull "${remoteFiles[i]}" "${localSeg}"`, {
-      stdio: "ignore",
-    });
-    execSync(`"${ADB}" -s ${serial} shell rm -f "${remoteFiles[i]}"`, { stdio: "ignore" });
-  }
-
-  // Build ffmpeg concat list
-  const concatList = join(tmpDir, "proof-concat.txt");
-  const listContent = localSegments.map((f) => `file '${f}'`).join("\n");
-  require("fs").writeFileSync(concatList, listContent);
-
+export function convertToMp4(webmPath: string, mp4Path: string): void {
   execSync(
-    `ffmpeg -f concat -safe 0 -i "${concatList}" -c copy "${localOutputPath}" -y`,
+    `ffmpeg -i "${webmPath}" -c:v libx264 -preset fast -crf 23 "${mp4Path}" -y`,
     { stdio: "ignore" },
   );
-
-  for (const seg of localSegments) {
-    try { require("fs").unlinkSync(seg); } catch { /* ignore */ }
-  }
-  try { require("fs").unlinkSync(concatList); } catch { /* ignore */ }
+  try { require("fs").unlinkSync(webmPath); } catch { /* ignore */ }
 }
 
 export function enableTouchIndicators(serial: string): void {

--- a/src/modes/simulator-ios.ts
+++ b/src/modes/simulator-ios.ts
@@ -1,0 +1,129 @@
+import { execSync, spawn, type ChildProcess } from "child_process";
+
+export interface SimDevice {
+  udid: string;
+  name: string;
+  state: string;
+  runtime: string;
+}
+
+export function assertIosReady(): void {
+  try {
+    execSync("xcrun --version", { stdio: "ignore" });
+  } catch {
+    throw new Error(
+      "xcrun not found. Install Xcode Command Line Tools: xcode-select --install"
+    );
+  }
+
+  try {
+    execSync("xcrun simctl help", { stdio: "ignore" });
+  } catch {
+    throw new Error(
+      "simctl not available. Ensure Xcode is installed and xcode-select points to it."
+    );
+  }
+}
+
+export function resolveIosDevice(deviceName?: string, os?: string): SimDevice {
+  const result = execSync("xcrun simctl list devices --json", { encoding: "utf-8" });
+  const data = JSON.parse(result);
+
+  const devices: SimDevice[] = [];
+  for (const [runtime, devs] of Object.entries(data.devices)) {
+    for (const dev of devs as any[]) {
+      if (!(dev as any).isAvailable) continue;
+      devices.push({
+        udid: dev.udid,
+        name: dev.name,
+        state: dev.state,
+        runtime,
+      });
+    }
+  }
+
+  if (!deviceName) {
+    const booted = devices.find((d) => d.state === "Booted");
+    if (!booted) {
+      throw new Error(
+        "No booted iOS Simulator found. Boot one with: xcrun simctl boot <device>"
+      );
+    }
+    return booted;
+  }
+
+  const matches = devices.filter((d) => {
+    const nameMatch = d.name === deviceName;
+    const osMatch = os ? d.runtime.includes(os) : true;
+    return nameMatch && osMatch;
+  });
+
+  if (matches.length === 0) {
+    const available = [...new Set(devices.map((d) => d.name))].join(", ");
+    throw new Error(
+      `No iOS Simulator found matching "${deviceName}"${os ? ` (iOS ${os})` : ""}. ` +
+      `Available: ${available}`
+    );
+  }
+
+  const booted = matches.find((d) => d.state === "Booted");
+  if (booted) return booted;
+
+  // Boot the first match
+  const target = matches[0];
+  execSync(`xcrun simctl boot ${target.udid}`);
+  return { ...target, state: "Booted" };
+}
+
+export interface IosRecordingHandle {
+  process: ChildProcess;
+  outputPath: string;
+  stop: () => Promise<string>;
+}
+
+export function startIosRecording(
+  udid: string,
+  outputPath: string,
+  codec: string = "h264",
+): IosRecordingHandle {
+  const proc = spawn(
+    "xcrun",
+    ["simctl", "io", udid, "recordVideo", "--codec", codec, outputPath],
+    { stdio: "ignore" },
+  );
+
+  return {
+    process: proc,
+    outputPath,
+    stop: () =>
+      new Promise((resolve, reject) => {
+        let settled = false;
+
+        proc.on("close", () => {
+          if (!settled) {
+            settled = true;
+            resolve(outputPath);
+          }
+        });
+
+        proc.on("error", (err) => {
+          if (!settled) {
+            settled = true;
+            reject(err);
+          }
+        });
+
+        // SIGINT triggers graceful stop and file finalization
+        proc.kill("SIGINT");
+
+        // Safety timeout
+        setTimeout(() => {
+          if (!settled) {
+            settled = true;
+            if (!proc.killed) proc.kill("SIGKILL");
+            resolve(outputPath);
+          }
+        }, 10_000);
+      }),
+  };
+}

--- a/src/modes/simulator-ios.ts
+++ b/src/modes/simulator-ios.ts
@@ -25,6 +25,18 @@ export function assertIosReady(): void {
   }
 }
 
+export function getBootedUdids(): Set<string> {
+  const result = execSync("xcrun simctl list devices booted --json", { encoding: "utf-8" });
+  const data = JSON.parse(result);
+  const udids = new Set<string>();
+  for (const devs of Object.values(data.devices)) {
+    for (const dev of devs as any[]) {
+      if (dev.state === "Booted") udids.add(dev.udid);
+    }
+  }
+  return udids;
+}
+
 export function resolveIosDevice(deviceName?: string, os?: string): SimDevice {
   const result = execSync("xcrun simctl list devices --json", { encoding: "utf-8" });
   const data = JSON.parse(result);

--- a/src/modes/simulator.ts
+++ b/src/modes/simulator.ts
@@ -3,6 +3,14 @@ import { join } from "path";
 import { stat, readFile } from "fs/promises";
 import { existsSync } from "fs";
 import { assertIosReady, resolveIosDevice, startIosRecording } from "./simulator-ios";
+import {
+  assertAndroidReady,
+  resolveAndroidDevice,
+  startAndroidRecording,
+  pullAndMergeRecording,
+  enableTouchIndicators,
+  disableTouchIndicators,
+} from "./simulator-android";
 import { getVideoDuration } from "../duration";
 import { findLatestXcresult, parseTapEvents } from "./xcresult";
 import { overlayTouchIndicators, type TapCoordinate } from "./touch-overlay";
@@ -22,7 +30,7 @@ export async function captureSimulator(
   const platform = options.platform ?? "ios";
 
   if (platform === "android") {
-    throw new Error("Android simulator capture is not yet implemented");
+    return captureAndroid(options, runDir, filePrefix, label);
   }
 
   assertIosReady();
@@ -81,6 +89,68 @@ export async function captureSimulator(
     } catch {
       // Non-fatal
     }
+  }
+
+  let duration: number;
+  try {
+    duration = await getVideoDuration(outputPath);
+  } catch {
+    duration = 0;
+  }
+
+  return {
+    path: outputPath,
+    mode: "simulator",
+    duration,
+    label,
+  };
+}
+
+async function captureAndroid(
+  options: CaptureOptions & { command: string },
+  runDir: string,
+  filePrefix: string,
+  label: string,
+): Promise<Recording> {
+  assertAndroidReady();
+
+  const device = resolveAndroidDevice(
+    options.simulator?.deviceName,
+    options.simulator?.deviceId,
+  );
+
+  const outputPath = join(runDir, `${filePrefix}.mp4`);
+
+  enableTouchIndicators(device.serial);
+
+  const recording = startAndroidRecording(device.serial, {
+    bitRate: options.simulator?.bitRate,
+    size: options.simulator?.size,
+  });
+
+  try {
+    await runCommand(options.command);
+    await sleep(500);
+  } finally {
+    await recording.stop();
+    disableTouchIndicators(device.serial);
+  }
+
+  pullAndMergeRecording(device.serial, recording.remoteFiles, outputPath);
+
+  if (!existsSync(outputPath)) {
+    throw new Error(
+      `Recording file not found at ${outputPath}. ` +
+      `The emulator may have crashed during recording.`
+    );
+  }
+
+  const fileStat = await stat(outputPath);
+  if (fileStat.size === 0) {
+    throw new Error(
+      `Recording file is empty at ${outputPath}. ` +
+      `Check that the emulator screen was visible during recording.`
+    );
   }
 
   let duration: number;

--- a/src/modes/simulator.ts
+++ b/src/modes/simulator.ts
@@ -7,7 +7,7 @@ import {
   assertAndroidReady,
   resolveAndroidDevice,
   startAndroidRecording,
-  pullAndMergeRecording,
+  convertToMp4,
   enableTouchIndicators,
   disableTouchIndicators,
 } from "./simulator-android";
@@ -120,10 +120,12 @@ async function captureAndroid(
   );
 
   const outputPath = join(runDir, `${filePrefix}.mp4`);
+  const webmPath = join(runDir, `${filePrefix}.webm`);
 
   enableTouchIndicators(device.serial);
 
-  const recording = startAndroidRecording(device.serial, {
+  const recordingStartTime = new Date();
+  const recording = startAndroidRecording(device.serial, webmPath, {
     bitRate: options.simulator?.bitRate,
     size: options.simulator?.size,
   });
@@ -136,7 +138,33 @@ async function captureAndroid(
     disableTouchIndicators(device.serial);
   }
 
-  pullAndMergeRecording(device.serial, recording.remoteFiles, outputPath);
+  convertToMp4(webmPath, outputPath);
+
+  // Post-process: overlay touch indicators from tap log if present
+  try {
+    const tapLog = process.env.PROOF_TAP_LOG ?? "/tmp/proof-android-taps.json";
+    if (existsSync(tapLog)) {
+      const entries = JSON.parse(require("fs").readFileSync(tapLog, "utf-8")) as Array<{
+        element: string; x: number; y: number; offsetMs: number;
+      }>;
+      if (entries.length > 0) {
+        const taps = entries.map((e) => ({
+          element: e.element,
+          timestamp: new Date(recordingStartTime.getTime() + e.offsetMs),
+          durationMs: 0,
+        }));
+        const coords = entries.map((e) => ({
+          element: e.element,
+          x: e.x,
+          y: e.y,
+          timestamp: new Date(recordingStartTime.getTime() + e.offsetMs).toISOString(),
+        }));
+        await overlayTouchIndicators(outputPath, taps, recordingStartTime, coords, 1);
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
 
   if (!existsSync(outputPath)) {
     throw new Error(

--- a/src/modes/simulator.ts
+++ b/src/modes/simulator.ts
@@ -1,0 +1,88 @@
+import { spawn } from "child_process";
+import { join } from "path";
+import { copyFile, stat } from "fs/promises";
+import { existsSync } from "fs";
+import { assertIosReady, resolveIosDevice, startIosRecording } from "./simulator-ios";
+import { getVideoDuration } from "../duration";
+import type { CaptureOptions, Recording } from "../types";
+
+export async function captureSimulator(
+  options: CaptureOptions & { command: string },
+  runDir: string,
+  filePrefix: string,
+): Promise<Recording> {
+  const label = options.label ?? "simulator";
+  const platform = options.platform ?? "ios";
+
+  if (platform === "android") {
+    throw new Error("Android simulator capture is not yet implemented");
+  }
+
+  assertIosReady();
+
+  const device = resolveIosDevice(
+    options.simulator?.deviceName,
+    options.simulator?.os,
+  );
+
+  const outputPath = join(runDir, `${filePrefix}.mp4`);
+
+  const recording = startIosRecording(
+    device.udid,
+    outputPath,
+    options.simulator?.codec,
+  );
+
+  // Run the user's command
+  const exitCode = await runCommand(options.command);
+
+  // Small delay to let the last frames render
+  await sleep(500);
+
+  // Stop recording
+  await recording.stop();
+
+  // Verify file exists
+  if (!existsSync(outputPath)) {
+    throw new Error(
+      `Recording file not found at ${outputPath}. ` +
+      `The simulator may have crashed during recording.`
+    );
+  }
+
+  const fileStat = await stat(outputPath);
+  if (fileStat.size === 0) {
+    throw new Error(
+      `Recording file is empty at ${outputPath}. ` +
+      `Check that the simulator screen was visible during recording.`
+    );
+  }
+
+  let duration: number;
+  try {
+    duration = await getVideoDuration(outputPath);
+  } catch {
+    duration = 0;
+  }
+
+  return {
+    path: outputPath,
+    mode: "simulator",
+    duration,
+    label,
+  };
+}
+
+function runCommand(command: string): Promise<number> {
+  return new Promise((resolve) => {
+    const proc = spawn("/bin/sh", ["-c", command], {
+      stdio: "inherit",
+    });
+    proc.on("close", (code) => resolve(code ?? 1));
+    proc.on("error", () => resolve(1));
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/modes/simulator.ts
+++ b/src/modes/simulator.ts
@@ -1,11 +1,11 @@
-import { spawn } from "child_process";
+import { execSync, spawn } from "child_process";
 import { join } from "path";
-import { stat } from "fs/promises";
+import { stat, readFile } from "fs/promises";
 import { existsSync } from "fs";
 import { assertIosReady, resolveIosDevice, startIosRecording } from "./simulator-ios";
 import { getVideoDuration } from "../duration";
 import { findLatestXcresult, parseTapEvents } from "./xcresult";
-import { overlayTouchIndicators } from "./touch-overlay";
+import { overlayTouchIndicators, type TapCoordinate } from "./touch-overlay";
 import type { CaptureOptions, Recording } from "../types";
 
 const XCODEBUILD_CLONE_WARNING =
@@ -37,8 +37,6 @@ export async function captureSimulator(
   }
 
   const outputPath = join(runDir, `${filePrefix}.mp4`);
-
-  // Record the start time for correlating xcresult tap timestamps
   const recordingStartTime = new Date();
 
   const recording = startIosRecording(
@@ -69,18 +67,19 @@ export async function captureSimulator(
     );
   }
 
-  // Post-process: overlay touch indicators from xcresult data
+  // Post-process: overlay touch indicators
   if (isXcodebuildTest(options.command)) {
     try {
       const xcresultPath = findLatestXcresult();
       if (xcresultPath) {
         const taps = parseTapEvents(xcresultPath);
         if (taps.length > 0) {
-          await overlayTouchIndicators(outputPath, taps, recordingStartTime);
+          const tapCoords = findTapCoordinates(device.udid);
+          await overlayTouchIndicators(outputPath, taps, recordingStartTime, tapCoords ?? undefined);
         }
       }
     } catch {
-      // Non-fatal: if overlay fails, the raw recording is still valid
+      // Non-fatal
     }
   }
 
@@ -97,6 +96,33 @@ export async function captureSimulator(
     duration,
     label,
   };
+}
+
+function findTapCoordinates(udid: string): TapCoordinate[] | null {
+  try {
+    const deviceDir = join(
+      process.env.HOME ?? "/",
+      "Library/Developer/CoreSimulator/Devices",
+      udid,
+      "data/Containers/Data/Application",
+    );
+
+    // Search for proof-taps.json in the device's app containers
+    const result = execSync(
+      `find "${deviceDir}" -name "proof-taps.json" -maxdepth 2 2>/dev/null | head -1`,
+      { encoding: "utf-8" },
+    ).trim();
+
+    if (!result || !existsSync(result)) return null;
+
+    const data = JSON.parse(
+      require("fs").readFileSync(result, "utf-8"),
+    ) as TapCoordinate[];
+
+    return data.length > 0 ? data : null;
+  } catch {
+    return null;
+  }
 }
 
 function isXcodebuildTest(command: string): boolean {

--- a/src/modes/simulator.ts
+++ b/src/modes/simulator.ts
@@ -4,6 +4,8 @@ import { stat } from "fs/promises";
 import { existsSync } from "fs";
 import { assertIosReady, resolveIosDevice, startIosRecording } from "./simulator-ios";
 import { getVideoDuration } from "../duration";
+import { findLatestXcresult, parseTapEvents } from "./xcresult";
+import { overlayTouchIndicators } from "./touch-overlay";
 import type { CaptureOptions, Recording } from "../types";
 
 const XCODEBUILD_CLONE_WARNING =
@@ -30,30 +32,25 @@ export async function captureSimulator(
     options.simulator?.os,
   );
 
-  // Warn if xcodebuild test is detected without clone-prevention flags
   if (isXcodebuildTest(options.command) && !hasClonePreventionFlags(options.command)) {
     console.error(`\n⚠️  ${XCODEBUILD_CLONE_WARNING}\n`);
   }
 
   const outputPath = join(runDir, `${filePrefix}.mp4`);
 
-  // Start recording the booted simulator
+  // Record the start time for correlating xcresult tap timestamps
+  const recordingStartTime = new Date();
+
   const recording = startIosRecording(
     device.udid,
     outputPath,
     options.simulator?.codec,
   );
 
-  // Run the user's command
   await runCommand(options.command);
-
-  // Small delay to let the last frames render
   await sleep(500);
-
-  // Stop recording
   await recording.stop();
 
-  // Verify file exists
   if (!existsSync(outputPath)) {
     throw new Error(
       `Recording file not found at ${outputPath}. ` +
@@ -70,6 +67,21 @@ export async function captureSimulator(
       `Recording file is empty at ${outputPath}. ` +
       `Check that the simulator screen was visible during recording.${hint}`
     );
+  }
+
+  // Post-process: overlay touch indicators from xcresult data
+  if (isXcodebuildTest(options.command)) {
+    try {
+      const xcresultPath = findLatestXcresult();
+      if (xcresultPath) {
+        const taps = parseTapEvents(xcresultPath);
+        if (taps.length > 0) {
+          await overlayTouchIndicators(outputPath, taps, recordingStartTime);
+        }
+      }
+    } catch {
+      // Non-fatal: if overlay fails, the raw recording is still valid
+    }
   }
 
   let duration: number;

--- a/src/modes/simulator.ts
+++ b/src/modes/simulator.ts
@@ -1,10 +1,15 @@
 import { spawn } from "child_process";
 import { join } from "path";
-import { copyFile, stat } from "fs/promises";
+import { stat } from "fs/promises";
 import { existsSync } from "fs";
 import { assertIosReady, resolveIosDevice, startIosRecording } from "./simulator-ios";
 import { getVideoDuration } from "../duration";
 import type { CaptureOptions, Recording } from "../types";
+
+const XCODEBUILD_CLONE_WARNING =
+  "Hint: xcodebuild test clones the simulator by default, which means the " +
+  "recording captures an idle screen. Add these flags to your xcodebuild command: " +
+  "-parallel-testing-enabled NO -disable-concurrent-destination-testing";
 
 export async function captureSimulator(
   options: CaptureOptions & { command: string },
@@ -25,8 +30,14 @@ export async function captureSimulator(
     options.simulator?.os,
   );
 
+  // Warn if xcodebuild test is detected without clone-prevention flags
+  if (isXcodebuildTest(options.command) && !hasClonePreventionFlags(options.command)) {
+    console.error(`\n⚠️  ${XCODEBUILD_CLONE_WARNING}\n`);
+  }
+
   const outputPath = join(runDir, `${filePrefix}.mp4`);
 
+  // Start recording the booted simulator
   const recording = startIosRecording(
     device.udid,
     outputPath,
@@ -34,7 +45,7 @@ export async function captureSimulator(
   );
 
   // Run the user's command
-  const exitCode = await runCommand(options.command);
+  await runCommand(options.command);
 
   // Small delay to let the last frames render
   await sleep(500);
@@ -52,9 +63,12 @@ export async function captureSimulator(
 
   const fileStat = await stat(outputPath);
   if (fileStat.size === 0) {
+    const hint = isXcodebuildTest(options.command)
+      ? ` ${XCODEBUILD_CLONE_WARNING}`
+      : "";
     throw new Error(
       `Recording file is empty at ${outputPath}. ` +
-      `Check that the simulator screen was visible during recording.`
+      `Check that the simulator screen was visible during recording.${hint}`
     );
   }
 
@@ -71,6 +85,16 @@ export async function captureSimulator(
     duration,
     label,
   };
+}
+
+function isXcodebuildTest(command: string): boolean {
+  return /xcodebuild\s+.*\btest\b/.test(command) ||
+    /xcodebuild\s+.*\btest-without-building\b/.test(command);
+}
+
+function hasClonePreventionFlags(command: string): boolean {
+  return command.includes("-parallel-testing-enabled NO") ||
+    command.includes("-disable-concurrent-destination-testing");
 }
 
 function runCommand(command: string): Promise<number> {

--- a/src/modes/touch-overlay.ts
+++ b/src/modes/touch-overlay.ts
@@ -1,13 +1,19 @@
 import { execSync, spawn } from "child_process";
-import { rename, unlink, writeFile } from "fs/promises";
+import { rename, unlink } from "fs/promises";
 import { existsSync } from "fs";
-import { join, dirname } from "path";
 import type { TapEvent } from "./xcresult";
 
 interface VideoInfo {
   width: number;
   height: number;
   duration: number;
+}
+
+export interface TapCoordinate {
+  element: string;
+  x: number;
+  y: number;
+  timestamp: string;
 }
 
 function getVideoInfo(videoPath: string): VideoInfo {
@@ -23,14 +29,25 @@ function getVideoInfo(videoPath: string): VideoInfo {
   };
 }
 
+function guessScaleFactor(videoWidth: number): number {
+  // iPhone Pro/Max: 1179px wide -> 393pt = 3x
+  // iPhone Plus: 1284px wide -> 428pt = 3x
+  // iPhone SE: 750px wide -> 375pt = 2x
+  // iPad: varies, but typically 2x
+  if (videoWidth >= 1170) return 3;
+  if (videoWidth >= 750) return 2;
+  return 2;
+}
+
 /**
  * Overlay red circle tap indicators onto the video using ffmpeg.
- * Each tap shows a red dot at screen center that fades in/out, plus an expanding ripple ring.
+ * Uses exact coordinates from tap log when available, falls back to screen center.
  */
 export async function overlayTouchIndicators(
   videoPath: string,
   taps: TapEvent[],
   recordingStartTime: Date,
+  tapCoordinates?: TapCoordinate[],
 ): Promise<void> {
   if (taps.length === 0) return;
 
@@ -41,60 +58,80 @@ export async function overlayTouchIndicators(
   }
 
   const info = getVideoInfo(videoPath);
+  const scale = guessScaleFactor(info.width);
 
-  const relativeTaps = taps.map((tap) => ({
-    element: tap.element,
-    t: (tap.timestamp.getTime() - recordingStartTime.getTime()) / 1000,
-  })).filter((t) => t.t >= 0 && t.t <= info.duration);
+  // Build coordinate map from tap log (element name -> pixel position)
+  const coordMap = new Map<string, { px: number; py: number }>();
+  if (tapCoordinates) {
+    for (const tc of tapCoordinates) {
+      coordMap.set(tc.element, {
+        px: Math.round(tc.x * scale),
+        py: Math.round(tc.y * scale),
+      });
+    }
+  }
+
+  const fallbackX = Math.round(info.width / 2);
+  const fallbackY = Math.round(info.height / 2);
+
+  const relativeTaps = taps.map((tap) => {
+    const coord = coordMap.get(tap.element);
+    return {
+      element: tap.element,
+      t: (tap.timestamp.getTime() - recordingStartTime.getTime()) / 1000,
+      px: coord?.px ?? fallbackX,
+      py: coord?.py ?? fallbackY,
+    };
+  }).filter((t) => t.t >= 0 && t.t <= info.duration);
 
   if (relativeTaps.length === 0) return;
 
-  // Generate the enable expression: show overlay when any tap is active
-  // Each tap shows for 0.4 seconds
-  const dotEnable = relativeTaps
-    .map((tap) => `between(t,${tap.t.toFixed(3)},${(tap.t + 0.4).toFixed(3)})`)
-    .join("+");
-
-  const rippleEnable = relativeTaps
-    .map((tap) => `between(t,${tap.t.toFixed(3)},${(tap.t + 0.5).toFixed(3)})`)
-    .join("+");
-
-  // Position: center of screen
-  const cx = Math.round(info.width / 2);
-  const cy = Math.round(info.height / 2);
-
-  // Use drawtext with a large Unicode filled circle (U+2B24) as an approximation
-  // For the dot: solid red circle
-  // For the ripple: hollow circle outline
-  const dotSize = 28;
-  const rippleSize = 18;
-
-  // Build a complex filtergraph using color sources and overlay
-  // Dot: small red filled circle overlay
-  const dotR = dotSize;
-  const dotFilter = `color=c=red@0.8:s=${dotR * 2}x${dotR * 2}:d=${info.duration},format=argb,geq=a='if(lt(sqrt((X-${dotR})*(X-${dotR})+(Y-${dotR})*(Y-${dotR})),${dotR}),200,0)':r='255':g='50':b='50'`;
-
-  // Ripple: expanding red ring overlay (static for simplicity)
+  // Build per-tap ffmpeg filter: each tap gets its own dot + ripple overlay
+  // at its specific coordinate
+  const dotR = 28;
   const ripR = dotR * 3;
   const borderW = 4;
-  const rippleFilter = `color=c=red@0.6:s=${ripR * 2}x${ripR * 2}:d=${info.duration},format=argb,geq=a='if(between(sqrt((X-${ripR})*(X-${ripR})+(Y-${ripR})*(Y-${ripR})),${ripR - borderW},${ripR}),180,0)':r='255':g='50':b='50'`;
 
-  const filter = [
-    `[0:v]null[main]`,
-    `${dotFilter}[dot]`,
-    `${rippleFilter}[ripple]`,
-    `[main][dot]overlay=x=${cx - dotR}:y=${cy - dotR}:enable='${dotEnable}'[withdot]`,
-    `[withdot][ripple]overlay=x=${cx - ripR}:y=${cy - ripR}:enable='${rippleEnable}'[out]`,
-  ].join(";");
+  const filterParts: string[] = [`[0:v]null[v0]`];
+  let inputIdx = 0;
+
+  for (const tap of relativeTaps) {
+    const tStart = tap.t.toFixed(3);
+    const dotEnd = (tap.t + 0.4).toFixed(3);
+    const ripEnd = (tap.t + 0.5).toFixed(3);
+
+    const dotSrc = `color=c=red@0.8:s=${dotR * 2}x${dotR * 2}:d=${info.duration},format=argb,geq=a='if(lt(sqrt((X-${dotR})*(X-${dotR})+(Y-${dotR})*(Y-${dotR})),${dotR}),200,0)':r='255':g='50':b='50'`;
+    const ripSrc = `color=c=red@0.6:s=${ripR * 2}x${ripR * 2}:d=${info.duration},format=argb,geq=a='if(between(sqrt((X-${ripR})*(X-${ripR})+(Y-${ripR})*(Y-${ripR})),${ripR - borderW},${ripR}),180,0)':r='255':g='50':b='50'`;
+
+    const dotLabel = `dot${inputIdx}`;
+    const ripLabel = `rip${inputIdx}`;
+    const prevLabel = `v${inputIdx}`;
+    const midLabel = `v${inputIdx}d`;
+    const nextLabel = `v${inputIdx + 1}`;
+
+    filterParts.push(`${dotSrc}[${dotLabel}]`);
+    filterParts.push(`${ripSrc}[${ripLabel}]`);
+    filterParts.push(
+      `[${prevLabel}][${dotLabel}]overlay=x=${tap.px - dotR}:y=${tap.py - dotR}:enable='between(t,${tStart},${dotEnd})'[${midLabel}]`,
+    );
+    filterParts.push(
+      `[${midLabel}][${ripLabel}]overlay=x=${tap.px - ripR}:y=${tap.py - ripR}:enable='between(t,${tStart},${ripEnd})'[${nextLabel}]`,
+    );
+
+    inputIdx++;
+  }
+
+  const finalLabel = `v${inputIdx}`;
+  const filter = filterParts.join(";");
 
   const tmpPath = videoPath.replace(".mp4", ".tmp.mp4");
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const proc = spawn("ffmpeg", [
       "-y",
       "-i", videoPath,
       "-filter_complex", filter,
-      "-map", "[out]",
+      "-map", `[${finalLabel}]`,
       "-map", "0:a?",
       "-codec:a", "copy",
       "-codec:v", "libx264",
@@ -103,22 +140,16 @@ export async function overlayTouchIndicators(
       tmpPath,
     ], { stdio: "pipe" });
 
-    let stderr = "";
-    proc.stderr?.on("data", (d: Buffer) => stderr += d.toString());
-
     proc.on("close", async (code) => {
       if (code === 0 && existsSync(tmpPath)) {
         try {
           await unlink(videoPath);
           await rename(tmpPath, videoPath);
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
+        } catch {}
       } else {
         try { await unlink(tmpPath); } catch {}
-        resolve(); // Don't fail the capture
       }
+      resolve();
     });
 
     proc.on("error", () => resolve());

--- a/src/modes/touch-overlay.ts
+++ b/src/modes/touch-overlay.ts
@@ -1,0 +1,126 @@
+import { execSync, spawn } from "child_process";
+import { rename, unlink, writeFile } from "fs/promises";
+import { existsSync } from "fs";
+import { join, dirname } from "path";
+import type { TapEvent } from "./xcresult";
+
+interface VideoInfo {
+  width: number;
+  height: number;
+  duration: number;
+}
+
+function getVideoInfo(videoPath: string): VideoInfo {
+  const result = execSync(
+    `ffprobe -v error -select_streams v:0 -show_entries stream=width,height -show_entries format=duration -of json "${videoPath}"`,
+    { encoding: "utf-8" },
+  );
+  const data = JSON.parse(result);
+  return {
+    width: data.streams?.[0]?.width ?? 1170,
+    height: data.streams?.[0]?.height ?? 2532,
+    duration: parseFloat(data.format?.duration ?? "0"),
+  };
+}
+
+/**
+ * Overlay red circle tap indicators onto the video using ffmpeg.
+ * Each tap shows a red dot at screen center that fades in/out, plus an expanding ripple ring.
+ */
+export async function overlayTouchIndicators(
+  videoPath: string,
+  taps: TapEvent[],
+  recordingStartTime: Date,
+): Promise<void> {
+  if (taps.length === 0) return;
+
+  try {
+    execSync("ffmpeg -version", { stdio: "ignore" });
+  } catch {
+    return;
+  }
+
+  const info = getVideoInfo(videoPath);
+
+  const relativeTaps = taps.map((tap) => ({
+    element: tap.element,
+    t: (tap.timestamp.getTime() - recordingStartTime.getTime()) / 1000,
+  })).filter((t) => t.t >= 0 && t.t <= info.duration);
+
+  if (relativeTaps.length === 0) return;
+
+  // Generate the enable expression: show overlay when any tap is active
+  // Each tap shows for 0.4 seconds
+  const dotEnable = relativeTaps
+    .map((tap) => `between(t,${tap.t.toFixed(3)},${(tap.t + 0.4).toFixed(3)})`)
+    .join("+");
+
+  const rippleEnable = relativeTaps
+    .map((tap) => `between(t,${tap.t.toFixed(3)},${(tap.t + 0.5).toFixed(3)})`)
+    .join("+");
+
+  // Position: center of screen
+  const cx = Math.round(info.width / 2);
+  const cy = Math.round(info.height / 2);
+
+  // Use drawtext with a large Unicode filled circle (U+2B24) as an approximation
+  // For the dot: solid red circle
+  // For the ripple: hollow circle outline
+  const dotSize = 28;
+  const rippleSize = 18;
+
+  // Build a complex filtergraph using color sources and overlay
+  // Dot: small red filled circle overlay
+  const dotR = dotSize;
+  const dotFilter = `color=c=red@0.8:s=${dotR * 2}x${dotR * 2}:d=${info.duration},format=argb,geq=a='if(lt(sqrt((X-${dotR})*(X-${dotR})+(Y-${dotR})*(Y-${dotR})),${dotR}),200,0)':r='255':g='50':b='50'`;
+
+  // Ripple: expanding red ring overlay (static for simplicity)
+  const ripR = dotR * 3;
+  const borderW = 4;
+  const rippleFilter = `color=c=red@0.6:s=${ripR * 2}x${ripR * 2}:d=${info.duration},format=argb,geq=a='if(between(sqrt((X-${ripR})*(X-${ripR})+(Y-${ripR})*(Y-${ripR})),${ripR - borderW},${ripR}),180,0)':r='255':g='50':b='50'`;
+
+  const filter = [
+    `[0:v]null[main]`,
+    `${dotFilter}[dot]`,
+    `${rippleFilter}[ripple]`,
+    `[main][dot]overlay=x=${cx - dotR}:y=${cy - dotR}:enable='${dotEnable}'[withdot]`,
+    `[withdot][ripple]overlay=x=${cx - ripR}:y=${cy - ripR}:enable='${rippleEnable}'[out]`,
+  ].join(";");
+
+  const tmpPath = videoPath.replace(".mp4", ".tmp.mp4");
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn("ffmpeg", [
+      "-y",
+      "-i", videoPath,
+      "-filter_complex", filter,
+      "-map", "[out]",
+      "-map", "0:a?",
+      "-codec:a", "copy",
+      "-codec:v", "libx264",
+      "-preset", "fast",
+      "-crf", "23",
+      tmpPath,
+    ], { stdio: "pipe" });
+
+    let stderr = "";
+    proc.stderr?.on("data", (d: Buffer) => stderr += d.toString());
+
+    proc.on("close", async (code) => {
+      if (code === 0 && existsSync(tmpPath)) {
+        try {
+          await unlink(videoPath);
+          await rename(tmpPath, videoPath);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      } else {
+        try { await unlink(tmpPath); } catch {}
+        resolve(); // Don't fail the capture
+      }
+    });
+
+    proc.on("error", () => resolve());
+  });
+}

--- a/src/modes/touch-overlay.ts
+++ b/src/modes/touch-overlay.ts
@@ -48,6 +48,7 @@ export async function overlayTouchIndicators(
   taps: TapEvent[],
   recordingStartTime: Date,
   tapCoordinates?: TapCoordinate[],
+  scaleFactor?: number,
 ): Promise<void> {
   if (taps.length === 0) return;
 
@@ -58,7 +59,7 @@ export async function overlayTouchIndicators(
   }
 
   const info = getVideoInfo(videoPath);
-  const scale = guessScaleFactor(info.width);
+  const scale = scaleFactor ?? guessScaleFactor(info.width);
 
   // Build coordinate map from tap log (element name -> pixel position)
   const coordMap = new Map<string, { px: number; py: number }>();

--- a/src/modes/xcresult.ts
+++ b/src/modes/xcresult.ts
@@ -1,0 +1,109 @@
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+export interface TapEvent {
+  element: string;
+  timestamp: Date;
+  durationMs: number;
+}
+
+export function findLatestXcresult(derivedDataPath?: string): string | null {
+  const base = derivedDataPath ??
+    join(process.env.HOME ?? "/", "Library/Developer/Xcode/DerivedData");
+
+  try {
+    const result = execSync(
+      `find "${base}" -name "*.xcresult" -maxdepth 5 -print0 | xargs -0 ls -dt 2>/dev/null | head -1`,
+      { encoding: "utf-8" },
+    ).trim();
+    return result && existsSync(result) ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseTapEvents(xcresultPath: string): TapEvent[] {
+  try {
+    const rootJson = execSync(
+      `xcrun xcresulttool get object --legacy --path "${xcresultPath}" --format json`,
+      { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
+    );
+    const root = JSON.parse(rootJson);
+
+    const testsRefId = findRef(root, "testsRef");
+    if (!testsRefId) return [];
+
+    const testsJson = execSync(
+      `xcrun xcresulttool get object --legacy --path "${xcresultPath}" --id "${testsRefId}" --format json`,
+      { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
+    );
+    const tests = JSON.parse(testsJson);
+
+    const summaryRefId = findRef(tests, "summaryRef");
+    if (!summaryRefId) return [];
+
+    const summaryJson = execSync(
+      `xcrun xcresulttool get object --legacy --path "${xcresultPath}" --id "${summaryRefId}" --format json`,
+      { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
+    );
+    const summary = JSON.parse(summaryJson);
+
+    const events: TapEvent[] = [];
+    collectTapActivities(summary, events);
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+function findRef(obj: any, key: string): string | null {
+  if (!obj || typeof obj !== "object") return null;
+  if (key in obj) {
+    const ref = obj[key];
+    if (ref?.id?._value) return ref.id._value;
+  }
+  for (const v of Object.values(obj)) {
+    if (Array.isArray(v)) {
+      for (const item of v) {
+        const found = findRef(item, key);
+        if (found) return found;
+      }
+    } else if (typeof v === "object" && v !== null) {
+      const found = findRef(v, key);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function collectTapActivities(obj: any, events: TapEvent[]): void {
+  if (!obj || typeof obj !== "object") return;
+
+  const typeName = obj?._type?._name ?? "";
+  if (typeName.includes("ActivitySummary")) {
+    const title: string = obj?.title?._value ?? "";
+    const tapMatch = title.match(/^Tap "(.+)"/);
+    if (tapMatch) {
+      const start = obj?.start?._value;
+      const finish = obj?.finish?._value;
+      if (start) {
+        const startDate = new Date(start);
+        const finishDate = finish ? new Date(finish) : startDate;
+        events.push({
+          element: tapMatch[1],
+          timestamp: startDate,
+          durationMs: finishDate.getTime() - startDate.getTime(),
+        });
+      }
+    }
+  }
+
+  for (const v of Object.values(obj)) {
+    if (Array.isArray(v)) {
+      for (const item of v) collectTapActivities(item, events);
+    } else if (typeof v === "object" && v !== null) {
+      collectTapActivities(v, events);
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type RecordingMode = "browser" | "terminal" | "auto";
+export type RecordingMode = "browser" | "terminal" | "simulator" | "auto";
 
 export interface ProofConfig {
   appName: string;
@@ -30,6 +30,15 @@ export interface CaptureOptions {
   description?: string;
   device?: string | string[];
   viewport?: string | string[];
+  platform?: "ios" | "android";
+  simulator?: {
+    deviceName?: string;
+    deviceId?: string;
+    os?: string;
+    codec?: string;
+    bitRate?: number;
+    size?: string;
+  };
 }
 
 export interface ProofEntry {
@@ -44,6 +53,7 @@ export interface ProofEntry {
   description: string;
   device?: string;
   viewport?: string;
+  platform?: "ios" | "android";
 }
 
 export interface ProofManifest {

--- a/test-app/ios/ProofTestApp/ProofTestApp.xcodeproj/project.pbxproj
+++ b/test-app/ios/ProofTestApp/ProofTestApp.xcodeproj/project.pbxproj
@@ -1,0 +1,384 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A1000001 /* ProofTestAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001 /* ProofTestAppApp.swift */; };
+		A1000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000002 /* ContentView.swift */; };
+		A1000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A2000003 /* Assets.xcassets */; };
+		A1000004 /* ProofTestAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000006 /* ProofTestAppUITests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A5000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A3000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A4000001;
+			remoteInfo = ProofTestApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A2000001 /* ProofTestAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProofTestAppApp.swift; sourceTree = "<group>"; };
+		A2000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A2000003 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A2000004 /* ProofTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProofTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2000005 /* ProofTestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProofTestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2000006 /* ProofTestAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProofTestAppUITests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A6000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6000002 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A7000001 = {
+			isa = PBXGroup;
+			children = (
+				A7000002 /* ProofTestApp */,
+				A7000003 /* ProofTestAppUITests */,
+				A7000004 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A7000002 /* ProofTestApp */ = {
+			isa = PBXGroup;
+			children = (
+				A2000001 /* ProofTestAppApp.swift */,
+				A2000002 /* ContentView.swift */,
+				A2000003 /* Assets.xcassets */,
+			);
+			path = ProofTestApp;
+			sourceTree = "<group>";
+		};
+		A7000003 /* ProofTestAppUITests */ = {
+			isa = PBXGroup;
+			children = (
+				A2000006 /* ProofTestAppUITests.swift */,
+			);
+			path = ProofTestAppUITests;
+			sourceTree = "<group>";
+		};
+		A7000004 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A2000004 /* ProofTestApp.app */,
+				A2000005 /* ProofTestAppUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A4000001 /* ProofTestApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A8000003 /* Build configuration list for PBXNativeTarget "ProofTestApp" */;
+			buildPhases = (
+				A9000001 /* Sources */,
+				A6000001 /* Frameworks */,
+				AA000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ProofTestApp;
+			productName = ProofTestApp;
+			productReference = A2000004 /* ProofTestApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A4000002 /* ProofTestAppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A8000005 /* Build configuration list for PBXNativeTarget "ProofTestAppUITests" */;
+			buildPhases = (
+				A9000002 /* Sources */,
+				A6000002 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A5000002 /* PBXTargetDependency */,
+			);
+			name = ProofTestAppUITests;
+			productName = ProofTestAppUITests;
+			productReference = A2000005 /* ProofTestAppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A3000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					A4000001 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+					A4000002 = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = A4000001;
+					};
+				};
+			};
+			buildConfigurationList = A8000001 /* Build configuration list for PBXProject "ProofTestApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A7000001;
+			productRefGroup = A7000004 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A4000001 /* ProofTestApp */,
+				A4000002 /* ProofTestAppUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AA000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000003 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A9000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000001 /* ProofTestAppApp.swift in Sources */,
+				A1000002 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A9000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1000004 /* ProofTestAppUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A5000002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A4000001 /* ProofTestApp */;
+			targetProxy = A5000001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		AB000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AB000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AB000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.automaze.ProofTestApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AB000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.automaze.ProofTestApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		AB000005 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.automaze.ProofTestAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ProofTestApp;
+			};
+			name = Debug;
+		};
+		AB000006 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.automaze.ProofTestAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ProofTestApp;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A8000001 /* Build configuration list for PBXProject "ProofTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB000001 /* Debug */,
+				AB000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A8000003 /* Build configuration list for PBXNativeTarget "ProofTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB000003 /* Debug */,
+				AB000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A8000005 /* Build configuration list for PBXNativeTarget "ProofTestAppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AB000005 /* Debug */,
+				AB000006 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A3000001 /* Project object */;
+}

--- a/test-app/ios/ProofTestApp/ProofTestApp.xcodeproj/project.pbxproj
+++ b/test-app/ios/ProofTestApp/ProofTestApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A1000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000002 /* ContentView.swift */; };
 		A1000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A2000003 /* Assets.xcassets */; };
 		A1000004 /* ProofTestAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000006 /* ProofTestAppUITests.swift */; };
+		A1000005 /* ProofTapLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000007 /* ProofTapLogger.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,6 +31,7 @@
 		A2000004 /* ProofTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProofTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2000005 /* ProofTestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProofTestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2000006 /* ProofTestAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProofTestAppUITests.swift; sourceTree = "<group>"; };
+		A2000007 /* ProofTapLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProofTapLogger.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				A2000006 /* ProofTestAppUITests.swift */,
+				A2000007 /* ProofTapLogger.swift */,
 			);
 			path = ProofTestAppUITests;
 			sourceTree = "<group>";
@@ -187,6 +190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A1000004 /* ProofTestAppUITests.swift in Sources */,
+				A1000005 /* ProofTapLogger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/test-app/ios/ProofTestApp/ProofTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/test-app/ios/ProofTestApp/ProofTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/test-app/ios/ProofTestApp/ProofTestApp/Assets.xcassets/Contents.json
+++ b/test-app/ios/ProofTestApp/ProofTestApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/test-app/ios/ProofTestApp/ProofTestApp/ContentView.swift
+++ b/test-app/ios/ProofTestApp/ProofTestApp/ContentView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var message = "Hello, World!"
+    @State private var tapCount = 0
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text(message)
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .accessibilityIdentifier("messageLabel")
+
+            Text("Tapped \(tapCount) times")
+                .font(.title2)
+                .foregroundColor(.secondary)
+                .accessibilityIdentifier("countLabel")
+
+            Button(action: {
+                tapCount += 1
+                message = tapCount == 1 ? "You tapped!" : "Tapped \(tapCount)x!"
+            }) {
+                Text("Tap Me")
+                    .font(.title2)
+                    .padding(.horizontal, 32)
+                    .padding(.vertical, 12)
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier("tapButton")
+
+            Button(action: {
+                tapCount = 0
+                message = "Hello, World!"
+            }) {
+                Text("Reset")
+                    .font(.body)
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier("resetButton")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/test-app/ios/ProofTestApp/ProofTestApp/ProofTestAppApp.swift
+++ b/test-app/ios/ProofTestApp/ProofTestApp/ProofTestAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ProofTestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/test-app/ios/ProofTestApp/ProofTestAppUITests/ProofTapLogger.swift
+++ b/test-app/ios/ProofTestApp/ProofTestAppUITests/ProofTapLogger.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+/// Logs tap coordinates to a JSON file for post-processing by Proof.
+/// Usage: call `element.proofTap()` instead of `element.tap()` in your XCUITest.
+/// The log file is written to /tmp/proof-taps.json on the simulator.
+final class ProofTapLogger {
+    static let shared = ProofTapLogger()
+
+    private var entries: [[String: Any]] = []
+    private let filePath: String
+
+    private init() {
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? NSTemporaryDirectory()
+        filePath = (home as NSString).appendingPathComponent("proof-taps.json")
+    }
+
+    func log(element: XCUIElement, accessibilityIdentifier: String) {
+        let frame = element.frame
+        let entry: [String: Any] = [
+            "element": accessibilityIdentifier,
+            "x": frame.midX,
+            "y": frame.midY,
+            "width": frame.width,
+            "height": frame.height,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+        ]
+        entries.append(entry)
+        flush()
+    }
+
+    private func flush() {
+        guard let data = try? JSONSerialization.data(withJSONObject: entries, options: .prettyPrinted) else { return }
+        try? data.write(to: URL(fileURLWithPath: filePath))
+    }
+
+    func reset() {
+        entries = []
+        try? FileManager.default.removeItem(atPath: filePath)
+    }
+}
+
+extension XCUIElement {
+    /// Tap with coordinate logging for Proof recordings.
+    @discardableResult
+    func proofTap(id: String? = nil) -> XCUIElement {
+        let identifier = id ?? self.identifier
+        ProofTapLogger.shared.log(element: self, accessibilityIdentifier: identifier)
+        self.tap()
+        return self
+    }
+}

--- a/test-app/ios/ProofTestApp/ProofTestAppUITests/ProofTestAppUITests.swift
+++ b/test-app/ios/ProofTestApp/ProofTestAppUITests/ProofTestAppUITests.swift
@@ -3,6 +3,7 @@ import XCTest
 final class ProofTestAppUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
+        ProofTapLogger.shared.reset()
     }
 
     func testTapButton() throws {
@@ -13,18 +14,18 @@ final class ProofTestAppUITests: XCTestCase {
         XCTAssertEqual(messageLabel.label, "Hello, World!")
 
         let tapButton = app.buttons["tapButton"]
-        tapButton.tap()
+        tapButton.proofTap()
 
         XCTAssertEqual(messageLabel.label, "You tapped!")
 
-        tapButton.tap()
+        tapButton.proofTap()
         XCTAssertEqual(messageLabel.label, "Tapped 2x!")
 
-        tapButton.tap()
+        tapButton.proofTap()
         XCTAssertEqual(messageLabel.label, "Tapped 3x!")
 
         let resetButton = app.buttons["resetButton"]
-        resetButton.tap()
+        resetButton.proofTap()
 
         XCTAssertEqual(messageLabel.label, "Hello, World!")
     }

--- a/test-app/ios/ProofTestApp/ProofTestAppUITests/ProofTestAppUITests.swift
+++ b/test-app/ios/ProofTestApp/ProofTestAppUITests/ProofTestAppUITests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+final class ProofTestAppUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testTapButton() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let messageLabel = app.staticTexts["messageLabel"]
+        XCTAssertEqual(messageLabel.label, "Hello, World!")
+
+        let tapButton = app.buttons["tapButton"]
+        tapButton.tap()
+
+        XCTAssertEqual(messageLabel.label, "You tapped!")
+
+        tapButton.tap()
+        XCTAssertEqual(messageLabel.label, "Tapped 2x!")
+
+        tapButton.tap()
+        XCTAssertEqual(messageLabel.label, "Tapped 3x!")
+
+        let resetButton = app.buttons["resetButton"]
+        resetButton.tap()
+
+        XCTAssertEqual(messageLabel.label, "Hello, World!")
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "types": ["bun-types"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## What

Adds a new `simulator` capture mode for recording iOS Simulator and Android emulator screens while running UI tests, with automatic tap indicator overlays.

## iOS

- Records via `xcrun simctl io recordVideo` (SIGINT to stop)
- Auto-detects booted simulator or boots by `--device-name` + `--os`
- Warns when `xcodebuild test` is missing clone-prevention flags
- **ProofTapLogger.swift** -- drop-in XCUITest extension: replace `element.tap()` with `element.proofTap()` to log element coordinates to `proof-taps.json` in the app container
- Post-processes with ffmpeg to overlay pixel-accurate red dot + ripple ring at each tapped element's center, scaled from UIKit points to video pixels

## Android

- Records via `adb emu screenrecord` (QEMU monitor protocol) -- works on Apple Silicon where `adb shell screenrecord` produces 0 frames due to the gfxstream graphics backend
- Auto-detects running emulator or boots AVD by name
- Converts `.webm` output to `.mp4` via ffmpeg
- Reads tap coordinates from `$PROOF_TAP_LOG` (default `/tmp/proof-android-taps.json`) and overlays indicators at native device pixel coordinates (scale=1)

## CLI

```bash
# iOS
proof capture --app my-app --mode simulator --platform ios \
  --device-name "iPhone 17 Pro" \
  --command "xcodebuild test -project ... -parallel-testing-enabled NO ..."

# Android  
proof capture --app my-app --mode simulator --platform android \
  --command "./run-tests.sh"
```

## Fixes

- Exclude test files from `tsc` compilation (stale `dist/*.test.js` were failing with missing `cli.ts`)
- Scope `bun test` to `src/` and `test-app/cli/` to skip Playwright `.spec.ts` files

## Tests

51 pass, 0 fail